### PR TITLE
Fix key naming, alt text, stale references, and incorrect signer list

### DIFF
--- a/mint-005.md
+++ b/mint-005.md
@@ -218,7 +218,7 @@ Signed by: $PK_1$, $PK_2$, $PAK_1$, $PAK_2$
 Transaction](https://mempool.space/signet/tx/2836d6af6b5c4bb01e926391f64771fb333193676040b24d4236ba0bb89a7008)
 
 ## Layer 2 Example Spend
-Signed by: $PK_1$, $PK_2$, $SAK$
+Signed by: $PK_1$, $PAK_1$, $PAK_2$
 
 [Reference Testnet
 Transaction](https://mempool.space/signet/tx/36aa3dfd0c7b4f4d8c7924c411e240920e4b4d36950ca59f68098b77162ae54d)

--- a/mint-006.md
+++ b/mint-006.md
@@ -6,6 +6,8 @@
 
 This vault is very similar to [mint-005.md](mint-005.md). The difference is the sequential order of the 3rd and 4th "layers", where the Principal is able to unilaterally move funds prior to the recovery layer. This is done for users who wish to make sure that funds will require the Principal to sign before the Primary Agent and Secondary Agent are able to move funds unilaterally. The recovery layer still exists to provide support to recover funds in the event the Principal has lost access to their keys.
 
+**Key differences from MINT-005:** First, the layer ordering is changed — the Sovereign Recovery Path (Recovery Keys only) comes *before* the Emergency Recovery Path (Primary Agent + Secondary Agent), meaning the Principal can unilaterally move funds before the agents gain the ability to recover without the Principal. Second, the Primary Agent Keys (PAKs) are listed as Key Set 1 and the Principal Keys (PKs) as Key Set 2 in the summary table and layer diagrams, which is the reverse of MINT-005's column ordering. Together, these changes result in a different miniscript output descriptor.
+
 
 ### More on Timelock Values
 
@@ -19,7 +21,7 @@ There are three timelocks used for this MinT:
 
 ### Keys
 
-In total, there are 10 keys in use for the 10-Key Collaborative Custody Vault, they are as follows:
+In total, there are 10 keys in use for the 3 Key Joint Custody, Sovereign First Vault, they are as follows:
 
 | Key Names | Description | Key Abbreviations | Key Symbol |
 |:--|:--:|:--:|:--:|
@@ -30,11 +32,11 @@ In total, there are 10 keys in use for the 10-Key Collaborative Custody Vault, t
 
 
 
-Below are reference diagrams on how the 10-Key Collaborative Custody Vault operates across time:
+Below are reference diagrams on how the 3 Key Joint Custody, Sovereign First Vault operates across time:
 
 ---
 
-### Collaborative Custody Summary Layers
+### Joint Custody Summary Layers
 
 Layer is used as an abstraction to segment the different eligible spending conditions, going in an ascending order of timelock values. At the start, only "Layer 1" is accessible for spending funds, over time, other spending conditions become available, but this does not restrict the ability to spend from a preceding layer.
 
@@ -63,9 +65,9 @@ Layer is used as an abstraction to segment the different eligible spending condi
   </tr>
   <tr>
     <td align="center">2 of 3 PAKs AND 2 of 3 PKs</td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK1"></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK2"></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK3"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK1"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK2"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK3"></td>
     <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_blue.png" alt="PK1"></td>
     <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_blue.png" alt="PK2"></td>
     <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_blue.png" alt="PK3"></td>
@@ -106,9 +108,9 @@ Layer is used as an abstraction to segment the different eligible spending condi
   </tr>
   <tr>
     <td align="center">2 of 3 PAKs AND 1 of 3 PKs AND BIP-113 time is greater than <code>`smallest_epoch_timestamp`</code></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK1"></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK2"></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK3"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK1"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK2"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK3"></td>
     <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_blue.png" alt="PK1"></td>
     <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_blue.png" alt="PK2"></td>
     <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_blue.png" alt="PK3"></td>
@@ -178,9 +180,9 @@ Layer is used as an abstraction to segment the different eligible spending condi
   </tr>
   <tr>
     <td align="center">2 of 3 PAKs AND SAK AND after BIP-113 time is greater than <code>`largest_epoch_timestamp`</code></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK1"></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK2"></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK3"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK1"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK2"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK3"></td>
     <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/83a8c241b2c2cf7ee940570aa97d8b0e1d751f55/assets/key_red.png" alt="SAK"></td>
     <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/unlock.png" alt="Timelock"></td>
   </tr>

--- a/mint-007.md
+++ b/mint-007.md
@@ -58,9 +58,9 @@ Layer is used as an abstraction to segment the different eligible spending condi
   </tr>
   <tr>
     <td align="center">2 of 3 PAKs AND PK</td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK1"></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK2"></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK3"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK1"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK2"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK3"></td>
     <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_blue.png" alt="PK"></td>
   </tr>
 </table>
@@ -91,9 +91,9 @@ Layer is used as an abstraction to segment the different eligible spending condi
   </tr>
   <tr>
     <td align="center">2 of 3 PAKs AND SAK AND BIP-113 time is greater than <code>`smallest_epoch_timestamp`</code></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK1"></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK2"></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK3"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK1"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK2"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK3"></td>
     <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/83a8c241b2c2cf7ee940570aa97d8b0e1d751f55/assets/key_red.png" alt="SAK"></td>
     <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/unlock.png" alt="Timelock"></td>
   </tr>

--- a/mint-008.md
+++ b/mint-008.md
@@ -63,9 +63,9 @@ Layer is used as an abstraction to segment the different eligible spending condi
   </tr>
   <tr>
     <td align="center">2 of 3 PAKs AND PK</td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK1"></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK2"></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK3"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK1"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK2"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK3"></td>
     <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_blue.png" alt="PK"></td>
   </tr>
 </table>
@@ -120,9 +120,9 @@ Layer is used as an abstraction to segment the different eligible spending condi
   </tr>
   <tr>
     <td align="center">2 of 3 PAKs AND SAK AND BIP-113 time is greater than <code>`largest_epoch_timestamp`</code></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK1"></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK2"></td>
-    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="CK3"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK1"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK2"></td>
+    <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/key_green.png" alt="PAK3"></td>
     <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/83a8c241b2c2cf7ee940570aa97d8b0e1d751f55/assets/key_red.png" alt="SAK"></td>
     <td align="center"><img src="https://raw.githubusercontent.com/Rob1Ham/miniscript-templates/main/assets/unlock.png" alt="Timelock"></td>
   </tr>

--- a/mint-009.md
+++ b/mint-009.md
@@ -120,10 +120,10 @@ Layer is used as an abstraction to segment the different eligible spending condi
 For this example, the `recovery_epoch_timestamp` is: 1727740800 (October 1, 2025, midnight UTC)
 
 - MINT-009 Output Descriptor:
-<code>wsh(andor(multi(1,$CK_1$,$CK_2$),multi(2,$CSK_1$,$CSK_2$,$CSK_3$),and_v(v:multi(1,$RK_1$,$RK_2$),after(`recovery_epoch_timestamp`))))</code>
+<code>wsh(andor(multi(1,$PAK_1$,$PAK_2$),multi(2,$SAK_1$,$SAK_2$,$SAK_3$),and_v(v:multi(1,$RK_1$,$RK_2$),after(`recovery_epoch_timestamp`))))</code>
 
 - Source Policy (FOR REFERENCE PURPOSES ONLY):
-<code>"or(and(thresh(2,pk($CSK_1$),pk($CSK_2$),pk($CSK_3$)),thresh(1,pk($CK_1$),pk($CK_2$))),and(after(`recovery_epoch_timestamp`),thresh(1,pk($RK_1$),pk($RK_2$))))"</code>
+<code>"or(and(thresh(2,pk($SAK_1$),pk($SAK_2$),pk($SAK_3$)),thresh(1,pk($PAK_1$),pk($PAK_2$))),and(after(`recovery_epoch_timestamp`),thresh(1,pk($RK_1$),pk($RK_2$))))"</code>
 
 
 
@@ -136,7 +136,7 @@ For the reference testnet transactions below, the following epoch timestamp was 
 
 ## Layer 1 Example Spend
 
-Signed by: $CK_1$, $CSK_1$, $CSK_2$
+Signed by: $PAK_1$, $SAK_1$, $SAK_2$
 
 
 [Reference Testnet Transaction](https://mempool.space/signet/tx/be2f19d0877237ec4fa900db79be2d9fdb469d60b6c6d3548da92cbef1210809)


### PR DESCRIPTION
## Summary

- **mint-005**: Fix Layer 2 Example Spend signers from `$PK_1$, $PK_2$, $SAK$` to `$PK_1$, $PAK_1$, $PAK_2$` (verified against actual signet transaction witness data — the transaction uses the Asset Recovery Path which requires 1-of-3 PKs + 2-of-3 PAKs, not SAK)
- **mint-006**: Fix stale "10-Key Collaborative Custody Vault" references to "3 Key Joint Custody, Sovereign First Vault", fix "Collaborative Custody Summary Layers" heading, add note explaining the intentional PK/PAK column ordering difference from MINT-005 (addressing apoelstra's review feedback)
- **mint-006/007/008**: Fix image alt text from `CK1/CK2/CK3` to `PAK1/PAK2/PAK3` to match the actual key names used in the documents
- **mint-009**: Fix `$CK_*$`/`$CSK_*$` to `$PAK_*$`/`$SAK_*$` in the output descriptor, source policy, and Layer 1 example spend signer list (these were the only 3 locations using the old naming; the rest of the document already used PAK/SAK)